### PR TITLE
Fix large note add failure

### DIFF
--- a/notecard/i2c-transactor.js
+++ b/notecard/i2c-transactor.js
@@ -86,8 +86,8 @@ class I2CTransactor {
         }
         
         var response = Buffer.alloc(0);
-        
-        await protocol.sendRequest(this, messageBuffer, I2CTransactor.MAX_PAYLOAD_CHUNK_BYTES);
+        const delayFn = () => timeout(2);
+        await protocol.sendRequest(this, messageBuffer, I2CTransactor.MAX_PAYLOAD_CHUNK_BYTES, {isCancelled:false}, delayFn);
 
         var numBytes = await this.pollForAvailableBytes();
 
@@ -134,8 +134,4 @@ module.exports = {I2CTransactor};
 
 
 const timeout = require('util').promisify(setTimeout)
-
-// function timeout(intervalMs){
-//     return new PromiseRejectionEvent((resolve,reject) => setTimeout(resolve, intervalMs));
-// }
 

--- a/test/test_serial_protocol.js
+++ b/test/test_serial_protocol.js
@@ -3,7 +3,8 @@ var assert = require('assert');
 
 const protocol = require('../notecard/bus-serial-protocol.js');
 
-//function createReadWriter(config={readBufferLength:1024,writeBufferLength:1024}){
+const sinon = require('sinon');
+
 function createReadWriter(){
     var rw = {
         readBuffer: Buffer.from(""), //Buffer.alloc(config.readBufferLength),
@@ -252,6 +253,22 @@ describe('bus-serial-protocol', () =>  {
             assert.strictEqual(rw.writeBuffer.slice(1,payload.length + 1).toString(), '{"req":"card.version"}\n', 'Payload value not in write buffer');
 
         })
+
+        it('should call delay function if it is provided on function interface', async () => {
+            rw.reset();
+            var payload = Buffer.from('{"req":"card.version"}\n');
+            var payloadSize = payload.length/2 + 1;
+
+            const spy = sinon.spy();
+            const delayFn = async () => {
+                spy();
+            }
+
+            await protocol.sendRequest(rw, payload, payloadSize,{isCancelled:false}, delayFn);
+            assert.ok(spy.calledOnce);
+
+
+        });
 
     });
 


### PR DESCRIPTION
Adds delay between message chunks when sending a request to the Notecard if the request is more than 253 bytes long.